### PR TITLE
Fix header name in index.src.html example code

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -233,7 +233,7 @@ If the resource is CORS-aware and supports these options, it might respond to th
 
 <pre>
 Access-Control-Allow-Origin: https://example.com
-Access-Control-Allow-Method: PUT
+Access-Control-Allow-Methods: PUT
 Access-Control-Allow-Headers: Special-Request-Header
 Access-Control-Allow-Credentials: true
 Access-Control-Max-Age: 60


### PR DESCRIPTION
Fix header name `Access-Control-Allow-Methods` in example. Was using incorrect name `Access-Control-Allow-Method`.